### PR TITLE
Fix issue LIMS-2651

### DIFF
--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -198,7 +198,7 @@ class ReferenceAnalysesView(AnalysesView):
             # bika.lims.graphics.controlchart.js
             format = "%Y-%m-%d %I:%M %p"
             cd = DT2dt(analysis.getResultCaptureDate()).strftime(format)
-            
+
             anrow = {'date': item['Captured'],
                      'min': smin,
                      'max': smax,
@@ -308,7 +308,8 @@ class ReferenceSamplesView(BikaListingView):
                               'path':{"query": ["/"], "level" : 0 }, }
         self.context_actions = {}
         self.show_select_column = True
-        request.set('disable_border', 1)
+        if not request.get('subclassed_SupplierReferenceSamplesView'):
+            request.set('disable_border', 1)
 
         self.columns = {
             'ID': {

--- a/bika/lims/browser/supplier.py
+++ b/bika/lims/browser/supplier.py
@@ -27,6 +27,7 @@ class SupplierInstrumentsView(InstrumentsView):
 class SupplierReferenceSamplesView(ReferenceSamplesView):
 
     def __init__(self, context, request):
+        request.set('subclassed_SupplierReferenceSamplesView', True)
         super(SupplierReferenceSamplesView, self).__init__(context, request)
         self.contentFilter['path']['query'] = '/'.join(context.getPhysicalPath())
         self.context_actions = {_('Add'):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/LIMS-2651
make tab bar visible for reference samples view under suppliers.

## Current behavior before PR
http://localhost:8080/Plone/bika_setup/bika_suppliers/supplier-2:
Tab bar invisible
http://localhost:8080/Plone/referencesamples
Tab bar invisible


## Desired behavior after PR is merged
http://localhost:8080/Plone/bika_setup/bika_suppliers/supplier-2:
Tab bar visible
http://localhost:8080/Plone/referencesamples
Tab bar invisible


--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
