### PR TITLE
invoice batch exports to pascal CSV

### DIFF
--- a/bika/lims/browser/invoicebatch.py
+++ b/bika/lims/browser/invoicebatch.py
@@ -180,15 +180,13 @@ class BatchFolderExportCSV(InvoiceBatchInvoicesView):
         ramdisk = StringIO()
         writer = csv.writer(ramdisk, delimiter=delimiter)
         assert(writer)
-
         writer.writerows(rows)
         result = ramdisk.getvalue()
         ramdisk.close()
-
         #stream file to browser
         setheader = RESPONSE.setHeader
-        setheader('Content-Length',len(result))
+        setheader('Content-Length', len(result))
         setheader('Content-Type',
-            'text/x-comma-separated-values')
+                  'text/x-comma-separated-values')
         setheader('Content-Disposition', 'inline; filename=%s' % filename)
         RESPONSE.write(result)


### PR DESCRIPTION
https://jira.bikalabs.com/browse/LIMS-2660


## Current behavior before PR
Invoice exports as pretty CSV

## Desired behavior after PR is merged
Invoice exports as pascal compatible CSV

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
