### PR TITLE
AN-127: Changed Failed Instrument viewlet permission

### DIFF
--- a/bika/lims/browser/instrument.zcml
+++ b/bika/lims/browser/instrument.zcml
@@ -75,7 +75,7 @@
         class="bika.lims.browser.instrument.InstrumentQCFailuresViewlet"
         manager="plone.app.layout.viewlets.interfaces.IAboveContent"
         template="templates/instrument_qc_failures_viewlet.pt"
-        permission="zope2.View"
+        permission="bika.lims.permissions.AddAnalysisRequest"
         layer="bika.lims.interfaces.IBikaLIMS"
     />
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/AN-127

## Current behavior before PR
     When an anonymous user request a password change, the InstrumentQCFailuresViewlet breaks

## Desired behavior after PR is merged
     Changed permissions on the view, so that logged in users can view the viewlet
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
