### PR TITLE
ARReport Title method fails if id is none

### DIFF
--- a/bika/lims/content/arreport.py
+++ b/bika/lims/content/arreport.py
@@ -56,6 +56,8 @@ class ARReport(BaseFolder):
     schema = schema
 
     def Title(self):
+        if len(self.getId()) == 0:
+            return "COAReport has no ID"
         coanr = self.getCOANR()
         arid = self.aq_parent.getId()
         if coanr:
@@ -63,6 +65,8 @@ class ARReport(BaseFolder):
         return "COA for {arid}".format(**locals())
 
     def Description(self):
+        if len(self.getId()) == 0:
+            return "COAReport has no ID"
         coanr = self.getCOANR()
         arid = self.aq_parent.getId()
         if coanr:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Cannot transition PR to published becuase ARReport title method fails
Fixed:  check if ARReport object has id before getting title

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
