### PR TITLE
AN-54: ClientUID was passed on createInvoice whereas it was expecting

### DIFF
--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2222,9 +2222,9 @@ class AnalysisRequest(BaseFolder):
             )
             invoice_batch.processForm()
 
-        client_uid = self.getClientUID()
+        client_title = self.getClientTitle()
         # Get the created invoice
-        invoice = invoice_batch.createInvoice(client_uid, [self, ])
+        invoice = invoice_batch.createInvoice(client_title, [self, ])
         invoice.setAnalysisRequest(self)
         # Set the created invoice in the schema
         self.Schema()['Invoice'].set(self, invoice)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
     ClientUID was passed on createInvoice whereas it was expecting ClientTitle
Linked issue: https://jira.bikalabs.com/browse/AN-54

## Current behavior before PR
      On the AR Invoice View, when clicking Create invoice an IndexError occurs

## Desired behavior after PR is merged
      Fix the error
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
